### PR TITLE
[FEAT] 내일 일기 개수 조회 기능 구현

### DIFF
--- a/src/main/java/com/sopkathon/tmdxo/api/DiaryController.java
+++ b/src/main/java/com/sopkathon/tmdxo/api/DiaryController.java
@@ -4,7 +4,9 @@ import com.sopkathon.tmdxo.api.dto.DiaryCreateRequest;
 import com.sopkathon.tmdxo.api.dto.DiaryInfosResponse;
 import com.sopkathon.tmdxo.global.common.response.ApiResponse;
 import com.sopkathon.tmdxo.service.DiaryService;
+
 import lombok.RequiredArgsConstructor;
+
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -34,10 +36,16 @@ public class DiaryController {
 		return ApiResponse.success(HttpStatus.OK, "좋아요 개수가 정상적으로 증가되었습니다.");
 	}
 
-	@PostMapping("/diary/write")
+	@PostMapping("/diary/add")
 	@ResponseStatus(HttpStatus.CREATED)
-	public ApiResponse<Void> createDiary(@RequestBody DiaryCreateRequest request) {
-		diaryService.createDiary(request);
+	public ApiResponse<Void> addDiary(@RequestBody DiaryCreateRequest request) {
+		diaryService.writeDiary(request);
 		return ApiResponse.success(HttpStatus.CREATED, "일기 작성에 성공하였습니다.");
+	}
+
+	@GetMapping("/diary/count")
+	@ResponseStatus(HttpStatus.OK)
+	public ApiResponse<Integer> findTomorrowDiaryCount() {
+		return ApiResponse.success(HttpStatus.OK, "내일 일기 개수 조회에 성공하였습니다.", diaryService.countTomorrowDiaries());
 	}
 }

--- a/src/main/java/com/sopkathon/tmdxo/service/DiaryService.java
+++ b/src/main/java/com/sopkathon/tmdxo/service/DiaryService.java
@@ -39,7 +39,7 @@ public class DiaryService {
 		diary.plusLikeCount();
 	}
 
-	public void createDiary(DiaryCreateRequest request) {
+	public void writeDiary(DiaryCreateRequest request) {
 		Like like = likeRepository.save(Like.newInstance());
 		Diary diary = Diary.builder()
 			.title(request.title())
@@ -52,5 +52,10 @@ public class DiaryService {
 			.build();
 
 		diaryRepository.save(diary);
+	}
+
+	public int countTomorrowDiaries() {
+		List<Diary> diaries = diaryRepository.findByDate(LocalDate.now().plusDays(1));
+		return diaries.size();
 	}
 }


### PR DESCRIPTION
## ✒️ 관련 이슈번호

- Closes #9

## 🔑 Key Changes
- 내용
  - `findByDate()`로 내일 날짜의 일기를 List로 만든 후, `size()`로 개수를 반환한다.

## 📢 To Reviewers

